### PR TITLE
Fix stack cleanup

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -86,12 +86,12 @@ while true; do
         echo "$(date) making api call to search for platinum tenants..."
         # shellcheck disable=SC2086
         # ignore shellcheck error for adding a quote as that causes the api call to fail
-        response=$(aws cloudformation list-stacks --stack-status-filter $STACK_STATUS_FILTER)
+        response=$(aws cloudformation list-stacks --stack-status-filter $STACK_STATUS_FILTER | sed 's/\\n//')
     else
         echo "$(date) making api call to search for platinum tenants..."
         # shellcheck disable=SC2086
         # ignore shellcheck error for adding a quote as that causes the api call to fail
-        response=$(aws cloudformation list-stacks --stack-status-filter $STACK_STATUS_FILTER --starting-token "$next_token")
+        response=$(aws cloudformation list-stacks --stack-status-filter $STACK_STATUS_FILTER --starting-token "$next_token"| sed 's/\\n//')
     fi
 
     tenant_stacks=$(echo "$response" | jq -r '.StackSummaries[].StackName | select(. | test("^stack-*"))')


### PR DESCRIPTION
On some instances TemplateDescription can have '\n' encoded inside it but when we process it through bash echo then it would cause line break resulting in invalid json.

Here is sample output I received from list-stacks that resulted in breaking cleanup.sh (notice \n in json response)

```
➜  aws-saas-factory-ref-solution-serverless-saas git:(adil/fix_stack_cleanup) ✗ saas aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE ROLLBACK_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE IMPORT_COMPLETE IMPORT_ROLLBACK_COMPLETE
...

        {
            "StackId": "arn:aws:cloudformation:us-east-1:264380604816:stack/serverless-saas-APIs-17O4B7RH955WQ/da23b660-e53e-11ed-8b82-12cd17ee3641",
            "StackName": "serverless-saas-APIs-17O4B7RH955WQ",
            "TemplateDescription": "Template to setup api gateway, apis, api keys and usage plan as part of bootstrap\n",
            "CreationTime": "2023-04-27T21:02:43.084000+00:00",
            "StackStatus": "CREATE_COMPLETE",
            "ParentId": "arn:aws:cloudformation:us-east-1:264380604816:stack/serverless-saas/ebd2a610-e53d-11ed-a021-12e60651c6c3",
            "RootId": "arn:aws:cloudformation:us-east-1:264380604816:stack/serverless-saas/ebd2a610-e53d-11ed-a021-12e60651c6c3",
            "DriftInformation": {
                "StackDriftStatus": "NOT_CHECKED"
            }
        },
...
```
