### PR TITLE
upgrade all lambda python versions to 3.9

### DIFF
--- a/server/nested_templates/bootstrap/lambdafunctions.yaml
+++ b/server/nested_templates/bootstrap/lambdafunctions.yaml
@@ -58,11 +58,11 @@ Resources:
       Description: Utilities for project
       ContentUri: ../../layers/
       CompatibleRuntimes:
-        - python3.8
+        - python3.9
       LicenseInfo: "MIT"
       RetentionPolicy: Retain
     Metadata:
-      BuildMethod: python3.8
+      BuildMethod: python3.9
 
   #Tenant Authorizer
   AuthorizerExecutionRole:

--- a/server/nested_templates/bootstrap/lambdafunctions.yaml
+++ b/server/nested_templates/bootstrap/lambdafunctions.yaml
@@ -135,7 +135,7 @@ Resources:
     Properties:
       CodeUri: ../../Resources/
       Handler: shared_service_authorizer.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt AuthorizerExecutionRole.Arn
       MemorySize: 256
       Tracing: Active
@@ -153,7 +153,7 @@ Resources:
     Properties:
       CodeUri: ../../Resources/
       Handler: tenant_authorizer.lambda_handler
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt AuthorizerExecutionRole.Arn
       MemorySize: 256
       Tracing: Active
@@ -246,7 +246,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.create_tenant_admin_user
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt CreateUserLambdaExecutionRole.Arn      
       Tracing: Active
       Layers:
@@ -289,7 +289,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.create_user
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt CreateUserLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -328,7 +328,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.update_user
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -367,7 +367,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.disable_user
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -405,7 +405,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.disable_users_by_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -443,7 +443,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.enable_users_by_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -481,7 +481,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.get_user
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -519,7 +519,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.get_users
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -597,7 +597,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.create_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -635,7 +635,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.activate_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -675,7 +675,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.get_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -713,7 +713,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.deactivate_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -753,7 +753,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.update_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -795,7 +795,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.get_tenants
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -832,7 +832,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.load_tenant_config
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -887,7 +887,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-registration.register_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt RegisterTenantLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -972,7 +972,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-provisioning.provision_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt ProvisionTenantLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -1038,7 +1038,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-provisioning.deprovision_tenant
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt DeProvisionTenantLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -1103,7 +1103,7 @@ Resources:
     Properties:
       CodeUri: ../../custom_resources/
       Handler: update_settings_table.handler
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt UpdateSettingsTableLambdaExecutionRole.Arn
       Layers: 
           - !Ref ServerlessSaaSLayers
@@ -1140,7 +1140,7 @@ Resources:
     Properties:
       CodeUri: ../../custom_resources/
       Handler: update_tenantstackmap_table.handler
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt UpdateTenantStackMapTableLambdaExecutionRole.Arn
       Layers: 
           - !Ref ServerlessSaaSLayers        

--- a/server/tenant-buildspec.yml
+++ b/server/tenant-buildspec.yml
@@ -4,6 +4,8 @@
 version: 0.2
 phases:
   install:    
+    runtime-versions:
+      python: 3.9
     commands:
       # Install packages or any pre-reqs in this phase.
       # Upgrading SAM CLI to latest version

--- a/server/tenant-template.yaml
+++ b/server/tenant-template.yaml
@@ -147,7 +147,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.get_product
-      Runtime: python3.8  
+      Runtime: python3.9
       Tracing: Active
       Role: !GetAtt ProductFunctionExecutionRole.Arn
       ReservedConcurrentExecutions: !If [IsPooledDeploy, !Ref "AWS::NoValue" , !Ref LambdaReserveConcurrency]
@@ -191,7 +191,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.get_products
-      Runtime: python3.8  
+      Runtime: python3.9
       Tracing: Active
       Role: !GetAtt ProductFunctionExecutionRole.Arn
       ReservedConcurrentExecutions: !If [IsPooledDeploy, !Ref "AWS::NoValue" , !Ref LambdaReserveConcurrency]
@@ -235,7 +235,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.create_product
-      Runtime: python3.8  
+      Runtime: python3.9
       Tracing: Active 
       Role: !GetAtt ProductFunctionExecutionRole.Arn 
       Layers: 
@@ -278,7 +278,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.update_product
-      Runtime: python3.8 
+      Runtime: python3.9
       Tracing: Active
       Role: !GetAtt ProductFunctionExecutionRole.Arn 
       Layers: 
@@ -321,7 +321,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.delete_product
-      Runtime: python3.8 
+      Runtime: python3.9
       Tracing: Active
       Role: !GetAtt ProductFunctionExecutionRole.Arn 
       Layers: 
@@ -402,7 +402,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.get_orders
-      Runtime: python3.8  
+      Runtime: python3.9
       Tracing: Active
       Role: !GetAtt OrderFunctionExecutionRole.Arn
       ReservedConcurrentExecutions: !If [IsPooledDeploy, !Ref "AWS::NoValue" , !Ref LambdaReserveConcurrency]
@@ -446,7 +446,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.get_order
-      Runtime: python3.8  
+      Runtime: python3.9
       Tracing: Active
       Role: !GetAtt OrderFunctionExecutionRole.Arn
       ReservedConcurrentExecutions: !If [IsPooledDeploy, !Ref "AWS::NoValue" , !Ref LambdaReserveConcurrency]
@@ -490,7 +490,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.create_order
-      Runtime: python3.8  
+      Runtime: python3.9
       Tracing: Active 
       Role: !GetAtt OrderFunctionExecutionRole.Arn 
       Layers: 
@@ -533,7 +533,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.update_order
-      Runtime: python3.8 
+      Runtime: python3.9
       Tracing: Active
       Role: !GetAtt OrderFunctionExecutionRole.Arn 
       Layers: 
@@ -576,7 +576,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.delete_order
-      Runtime: python3.8 
+      Runtime: python3.9
       Tracing: Active
       Role: !GetAtt OrderFunctionExecutionRole.Arn 
       Layers: 
@@ -1254,7 +1254,7 @@ Resources:
     Properties:
       CodeUri: custom_resources/
       Handler: update_usage_plan.handler
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt UpdateUsagePlanLambdaExecutionRole.Arn
       Layers: 
           - !Ref ServerlessSaaSLayers
@@ -1309,7 +1309,7 @@ Resources:
     Properties:
       CodeUri: custom_resources/
       Handler: update_tenant_apigatewayurl.handler
-      Runtime: python3.8
+      Runtime: python3.9
       Role: !GetAtt UpdateTenantApiGatewayUrlLambdaExecutionRole.Arn
       Layers: 
           - !Ref ServerlessSaaSLayers

--- a/server/tenant-template.yaml
+++ b/server/tenant-template.yaml
@@ -55,11 +55,11 @@ Resources:
       Description: Utilities for project
       ContentUri: layers/
       CompatibleRuntimes:
-        - python3.8          
+        - python3.9
       LicenseInfo: 'MIT'
       RetentionPolicy: Retain      
     Metadata:
-      BuildMethod: python3.8   
+      BuildMethod: python3.9
   
   ProductTable:
     Type: AWS::DynamoDB::Table


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change is meant to fix:

```
urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2k-fips  26 Jan 2017. See: https://github.com/urllib3/urllib3/issues/2168
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
