### PR TITLE
update to latest codebuild image for tenant pipeline

### DIFF
--- a/server/TenantPipeline/lib/serverless-saas-stack.ts
+++ b/server/TenantPipeline/lib/serverless-saas-stack.ts
@@ -79,7 +79,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
     //Declare a new CodeBuild project
     const buildProject = new codebuild.PipelineProject(this, 'Build', {
       buildSpec : codebuild.BuildSpec.fromSourceFilename("server/tenant-buildspec.yml"),
-      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_2 },
+      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_4 },
       environmentVariables: {
         'PACKAGE_BUCKET': {
           value: artifactsBucket.bucketName


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We are currently using the an older version of the codebuild image (`codebuild.LinuxBuildImage.AMAZON_LINUX_2_2`). This PR updates the codebuild project to use the latest codebuild image`codebuild.LinuxBuildImage.AMAZON_LINUX_2_4`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
