### PR TITLE
Update serverless-saas-stack.ts

### DIFF
--- a/server/TenantPipeline/lib/serverless-saas-stack.ts
+++ b/server/TenantPipeline/lib/serverless-saas-stack.ts
@@ -31,7 +31,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
 
     const lambdaFunction = new Function(this, "deploy-tenant-stack", {
         handler: "lambda-deploy-tenant-stack.lambda_handler",
-        runtime: Runtime.PYTHON_3_8,
+        runtime: Runtime.PYTHON_3_9,
         code: new AssetCode(`./resources`),
         memorySize: 512,
         timeout: Duration.seconds(10),


### PR DESCRIPTION
Python runtime change from 3.8 to 3.9 in order to ensure consistent deployment of the serverless-saas-pipeline deploy phase

*Issue #, if available:*
lambda-deploy-tenant-stack.lambda_handler still leveraging Python3.8  Issue#56
*Description of changes:*

serverless-saas-stack.ts modified to use Python 3.9 runtime.  Lambda application deployment changed and Codepipeline for serverless-saas-pipeline deploy phase launches correctly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
