### PR TITLE
Update python, nodejs, and codebuild versions

### DIFF
--- a/Cloud9Setup/increase-disk-size.sh
+++ b/Cloud9Setup/increase-disk-size.sh
@@ -37,10 +37,11 @@ then
   sudo growpart /dev/xvda 1
 
   # Expand the size of the file system.
-  # Check if we're on AL2
-  STR=$(cat /etc/os-release)
-  SUB="VERSION_ID=\"2\""
-  if [[ "$STR" == *"$SUB"* ]]
+  # Check if we're on AL2 or AL2023
+  STR=$(cat /etc/os-release)  
+  AL2="VERSION_ID=\"2\""
+  AL2023="VERSION_ID=\"2023\""
+  if [[ "$STR" =~ "$AL2"|"$AL2023" ]]
   then
     sudo xfs_growfs -d /
   else
@@ -54,8 +55,9 @@ else
   # Expand the size of the file system.
   # Check if we're on AL2
   STR=$(cat /etc/os-release)
-  SUB="VERSION_ID=\"2\""
-  if [[ "$STR" == *"$SUB"* ]]
+  AL2="VERSION_ID=\"2\""
+  AL2023="VERSION_ID=\"2023\""
+  if [[ "$STR" =~ "$AL2"|"$AL2023" ]]
   then
     sudo xfs_growfs -d /
   else

--- a/Cloud9Setup/pre-requisites.sh
+++ b/Cloud9Setup/pre-requisites.sh
@@ -1,12 +1,10 @@
 #!/bin/bash -x
 . /home/ec2-user/.nvm/nvm.sh
 
-#Install python3.8
-sudo yum install -y amazon-linux-extras
-sudo amazon-linux-extras enable python3.8
-sudo yum install -y python3.8
-sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
-sudo alternatives --set python3 /usr/bin/python3.8
+# Install Python 3.11, available as a package on AL2023
+sudo yum install -y python3.11
+sudo alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+sudo alternatives --set python3 /usr/bin/python3.11
 
 # Uninstall aws cli v1 and Install aws cli version-2.3.0
 sudo pip2 uninstall awscli -y
@@ -41,13 +39,13 @@ rm get-pip.py
 
 python3 -m pip install git-remote-codecommit==1.15.1
 
-# Install node v16.20.0
-echo "Installing node v16.20.0"
+# Install node v20.12.2
+echo "Installing node v20.12.2"
 nvm deactivate
 nvm uninstall node
-nvm install v16.20.0
-nvm use v16.20.0
-nvm alias default v16.20.0
+nvm install v20.12.2
+nvm use v20.12.2
+nvm alias default v20.12.2
 
 # Install cdk cli version ^2.0.0
 echo "Installing cdk cli version ^2.0.0"

--- a/server/TenantPipeline/lib/serverless-saas-stack.ts
+++ b/server/TenantPipeline/lib/serverless-saas-stack.ts
@@ -46,7 +46,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
 
     const lambdaFunctionPrep = new Function(this, "prep-deploy", {
         handler: "lambda-prepare-deploy.lambda_handler",
-        runtime: Runtime.PYTHON_3_9,
+        runtime: Runtime.PYTHON_3_12,
         code: new AssetCode(`./resources`),
         memorySize: 512,
         timeout: Duration.seconds(10),
@@ -131,7 +131,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
     //Declare a new CodeBuild project
     const buildProject = new codebuild.PipelineProject(this, 'Build', {
       buildSpec : codebuild.BuildSpec.fromSourceFilename("server/tenant-buildspec.yml"),
-      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_4 },
+      environment: { buildImage: codebuild.LinuxBuildImage.AMAZON_LINUX_2_5 },
       environmentVariables: {
         'PACKAGE_BUCKET': {
           value: artifactsBucket.bucketName
@@ -174,7 +174,7 @@ export class ServerlessSaaSStack extends cdk.Stack {
     
     const lambdaFunctionIterator = new Function(this, "WaveIterator", {
       handler: "iterator.lambda_handler",
-      runtime: Runtime.PYTHON_3_9,
+      runtime: Runtime.PYTHON_3_12,
       code: lambda.Code.fromAsset("resources", {exclude: ['*.json']}),
       memorySize: 512,
       timeout: Duration.seconds(10),

--- a/server/nested_templates/bootstrap/lambdafunctions.yaml
+++ b/server/nested_templates/bootstrap/lambdafunctions.yaml
@@ -58,11 +58,11 @@ Resources:
       Description: Utilities for project
       ContentUri: ../../layers/
       CompatibleRuntimes:
-        - python3.9
+        - python3.12
       LicenseInfo: "MIT"
       RetentionPolicy: Retain
     Metadata:
-      BuildMethod: python3.9
+      BuildMethod: python3.12
 
   #Tenant Authorizer
   AuthorizerExecutionRole:
@@ -135,7 +135,7 @@ Resources:
     Properties:
       CodeUri: ../../Resources/
       Handler: shared_service_authorizer.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt AuthorizerExecutionRole.Arn
       MemorySize: 256
       Tracing: Active
@@ -153,7 +153,7 @@ Resources:
     Properties:
       CodeUri: ../../Resources/
       Handler: tenant_authorizer.lambda_handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt AuthorizerExecutionRole.Arn
       MemorySize: 256
       Tracing: Active
@@ -246,7 +246,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.create_tenant_admin_user
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt CreateUserLambdaExecutionRole.Arn      
       Tracing: Active
       Layers:
@@ -289,7 +289,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.create_user
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt CreateUserLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -328,7 +328,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.update_user
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -367,7 +367,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.disable_user
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -405,7 +405,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.disable_users_by_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -443,7 +443,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.enable_users_by_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -481,7 +481,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.get_user
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -519,7 +519,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: user-management.get_users
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantUserPoolLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -597,7 +597,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.create_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -635,7 +635,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.activate_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -675,7 +675,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.get_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -713,7 +713,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.deactivate_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -753,7 +753,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.update_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -795,7 +795,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.get_tenants
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -832,7 +832,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-management.load_tenant_config
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt TenantManagementLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -887,7 +887,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-registration.register_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt RegisterTenantLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -972,7 +972,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-provisioning.provision_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt ProvisionTenantLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -1038,7 +1038,7 @@ Resources:
     Properties:
       CodeUri: ../../TenantManagementService/
       Handler: tenant-provisioning.deprovision_tenant
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt DeProvisionTenantLambdaExecutionRole.Arn
       Tracing: Active
       Layers:
@@ -1103,7 +1103,7 @@ Resources:
     Properties:
       CodeUri: ../../custom_resources/
       Handler: update_settings_table.handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt UpdateSettingsTableLambdaExecutionRole.Arn
       Layers: 
           - !Ref ServerlessSaaSLayers
@@ -1140,7 +1140,7 @@ Resources:
     Properties:
       CodeUri: ../../custom_resources/
       Handler: update_tenantstackmap_table.handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt UpdateTenantStackMapTableLambdaExecutionRole.Arn
       Layers: 
           - !Ref ServerlessSaaSLayers        

--- a/server/tenant-buildspec.yml
+++ b/server/tenant-buildspec.yml
@@ -5,7 +5,7 @@ version: 0.2
 phases:
   install:    
     runtime-versions:
-      python: 3.9
+      python: 3.12
     commands:
       # Install packages or any pre-reqs in this phase.
       # Upgrading SAM CLI to latest version

--- a/server/tenant-template.yaml
+++ b/server/tenant-template.yaml
@@ -55,11 +55,11 @@ Resources:
       Description: Utilities for project
       ContentUri: layers/
       CompatibleRuntimes:
-        - python3.9
+        - python3.12
       LicenseInfo: 'MIT'
       RetentionPolicy: Retain      
     Metadata:
-      BuildMethod: python3.9
+      BuildMethod: python3.12
   
   ProductTable:
     Type: AWS::DynamoDB::Table
@@ -147,7 +147,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.get_product
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active
       Role: !GetAtt ProductFunctionExecutionRole.Arn
       ReservedConcurrentExecutions: !If [IsPooledDeploy, !Ref "AWS::NoValue" , !Ref LambdaReserveConcurrency]
@@ -191,7 +191,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.get_products
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active
       Role: !GetAtt ProductFunctionExecutionRole.Arn
       ReservedConcurrentExecutions: !If [IsPooledDeploy, !Ref "AWS::NoValue" , !Ref LambdaReserveConcurrency]
@@ -235,7 +235,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.create_product
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active 
       Role: !GetAtt ProductFunctionExecutionRole.Arn 
       Layers: 
@@ -278,7 +278,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.update_product
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active
       Role: !GetAtt ProductFunctionExecutionRole.Arn 
       Layers: 
@@ -321,7 +321,7 @@ Resources:
     Properties:
       CodeUri: ProductService/
       Handler: product_service.delete_product
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active
       Role: !GetAtt ProductFunctionExecutionRole.Arn 
       Layers: 
@@ -402,7 +402,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.get_orders
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active
       Role: !GetAtt OrderFunctionExecutionRole.Arn
       ReservedConcurrentExecutions: !If [IsPooledDeploy, !Ref "AWS::NoValue" , !Ref LambdaReserveConcurrency]
@@ -446,7 +446,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.get_order
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active
       Role: !GetAtt OrderFunctionExecutionRole.Arn
       ReservedConcurrentExecutions: !If [IsPooledDeploy, !Ref "AWS::NoValue" , !Ref LambdaReserveConcurrency]
@@ -490,7 +490,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.create_order
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active 
       Role: !GetAtt OrderFunctionExecutionRole.Arn 
       Layers: 
@@ -533,7 +533,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.update_order
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active
       Role: !GetAtt OrderFunctionExecutionRole.Arn 
       Layers: 
@@ -576,7 +576,7 @@ Resources:
     Properties:
       CodeUri: OrderService/
       Handler: order_service.delete_order
-      Runtime: python3.9
+      Runtime: python3.12
       Tracing: Active
       Role: !GetAtt OrderFunctionExecutionRole.Arn 
       Layers: 
@@ -1254,7 +1254,7 @@ Resources:
     Properties:
       CodeUri: custom_resources/
       Handler: update_usage_plan.handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt UpdateUsagePlanLambdaExecutionRole.Arn
       Layers: 
           - !Ref ServerlessSaaSLayers
@@ -1309,7 +1309,7 @@ Resources:
     Properties:
       CodeUri: custom_resources/
       Handler: update_tenant_apigatewayurl.handler
-      Runtime: python3.9
+      Runtime: python3.12
       Role: !GetAtt UpdateTenantApiGatewayUrlLambdaExecutionRole.Arn
       Layers: 
           - !Ref ServerlessSaaSLayers


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update AWS Lambda runtimes to `PYTHON_3_12`, which uses AL2023 ([ref](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported))
* Update CodeBuild image to `AMAZON_LINUX_2_5`, which is also based on AL2023, and supports python3.12 ([ref](https://github.com/aws/aws-codebuild-docker-images/blob/master/al2/x86_64/standard/5.0/Dockerfile#L302))
* Update `Cloud9Setup` scripts, since the default Cloud9 platform is now AL2023. Note: the Python version in the Cloud9 environment is one minor version behind the runtimes on 3.11, but the Cloud9 environment was also one minor version behind previously - so hopefully this isn't an issue. AL2023 did not have a python3.12 package available at time of writing ([ref](https://github.com/amazonlinux/amazon-linux-2023/issues/483)).

*Manual e2e tests performed (based on workshop, lab 1 through 5):*

1.  Add a Tenant (tenant1) through SaaS Admin.
2. As Tenant Admin for tenant1, add product on SaaS Commerce Application. Add order for product.
3. Add a Tenant (tenant2) through Landing page.
4. As a Tenant Admin for tenant2, add product on SaaS Commerce Application. Add erder for product. Verify isolation from tenant1 in Application, and entries in the Product-pooled and Order-pooled DynamoDB tables.
5. Add a Tenant (tenant3) through Landing page as Platinum tier.
6. Verify the CodePipeline `serverless-saas-pipeline` workflow completes successfully, and a new environment for the platinum tenant is deployed through CloudFormation successfully (i.e. - `stack-<tenantId>`).
7. As a Tenant Admin for tenant3, add Product on SaaS Commerce Application. Add order for product. Verify product and order items are added to their respective, isolated tenant3 DynamoDB tables.

Bootstrapping on Cloud9 to be tested next.

I believe the client environment files are tracked in this repo intentionally, so I did not remove and add them to `.gitignore`. On my local branch, I used `git update-index` to skip the respective `clients/{Admin,Application,Landing}/environments/*` files. 
i.e. -
`git update-index --skip-worktree clients/Admin/src/environments/*`

I also skipped `server/samconfig-boostrap.toml` and `clients/Admin/src/aws-exports.ts`. This shouldn't have any effect on the remote branches, but JFYI and for posterity.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
